### PR TITLE
enable mounting ES data directory to docker host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN wget -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key 
     ln -s /etc/elasticsearch/logging.yml /usr/share/elasticsearch/config/logging.yml
 
 VOLUME ["/var/lib/elasticsearch"]
+VOLUME ["/usr/share/elasticsearch/data/"]
 
 ADD conf/elasticsearch.default /etc/default/elasticsearch
 ADD conf/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml


### PR DESCRIPTION
Would be nice to be able to persist ES/Logstash data between restarts.
